### PR TITLE
Fix urllib import to fix crash on SETDESC - fixes #1

### DIFF
--- a/trezor_gpg_pinentry_tk.py
+++ b/trezor_gpg_pinentry_tk.py
@@ -4,7 +4,7 @@ import traceback
 import argparse
 import os
 import os.path
-import urllib
+import urllib.parse
 import tkinter as tk
 import io
 import termios


### PR DESCRIPTION
Fixes crash on SETDESC call: issue #1 
```
AttributeError: module 'urllib' has no attribute 'parse'
```